### PR TITLE
🔧 fix: 修复 load_nvm 启动优化逻辑错误

### DIFF
--- a/load_nvm.fish
+++ b/load_nvm.fish
@@ -2,8 +2,7 @@
 # Automatically load nvm version when PWD changes
 function load_nvm --on-variable="PWD" --description 'Automatically switch Node.js versions based on .nvmrc'
   # Fast startup optimization - only do minimal work during fish startup
-  set -l is_startup (not set -q __nvm_fish_pwd_initialized)
-  if test -z "$is_startup"
+  if not set -q __nvm_fish_pwd_initialized
     set -g __nvm_fish_pwd_initialized 1
     # On startup, only set the flag and exit immediately
     # Actual nvm operations will happen on first directory change


### PR DESCRIPTION
## 问题描述
`.nvmrc` 自动切换 Node.js 版本功能不生效。用户在包含 `.nvmrc` 文件的目录之间切换时，Node.js 版本不会自动切换。

## 根本原因
`load_nvm.fish` 中的启动优化逻辑存在错误：

```fish
set -l is_startup (not set -q __nvm_fish_pwd_initialized)
if test -z "$is_startup"
```

这个条件判断始终为 false，导致：
- Fish 启动时执行了完整的 nvm 检查逻辑（影响启动速度）
- 启动优化机制完全失效

## 修复方案
将复杂的条件判断简化为直接的逻辑：

```fish
if not set -q __nvm_fish_pwd_initialized
    set -g __nvm_fish_pwd_initialized 1
    return
end
```

## 修复效果
- ✅ Fish 启动时只设置标志并快速返回，不影响启动速度
- ✅ 目录切换时执行完整的版本检查逻辑
- ✅ 自动 `.nvmrc` 版本切换功能恢复正常工作

## 测试验证
已验证修复后的功能正常工作：
- 创建包含 `.nvmrc` 的目录
- 切换目录时自动切换 Node.js 版本
- Fish 启动速度不受影响

## 类型
- Bug 修复
- 性能优化

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Optimized startup behavior with an early-return guard on initial launch, reducing shell startup time.
  - Skips unnecessary work during startup while preserving existing directory-change behavior.
  - No changes to commands or configuration; day-to-day usage remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->