### PR TITLE
🔧 修复v1.1.0版本的关键问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ Thumbs.db
 
 # custom
 aur-push.sh
+CLAUDE.md

--- a/bass_helper.fish
+++ b/bass_helper.fish
@@ -11,54 +11,54 @@ function __nvm_setup_bass --description 'Setup bass environment for nvm integrat
     # Check plugin managers and show status
     echo -n "  fisher: "
     if command -v fisher >/dev/null 2>&1
-        echo -e "\033[32m✓\033[0m"
+        echo -e " \033[32m✔\033[0m"
         echo "Installing bass via fisher..."
         # Show fisher output
         fisher install edc/bass
         if test $status -eq 0
-            echo -e "\033[32mBass installed successfully via fisher\033[0m"
+            echo -e " \033[32mBass installed successfully via fisher\033[0m"
             echo "Please restart your fish shell to complete setup"
             return 0
         else
-            echo -e "\033[31mFailed to install via fisher\033[0m"
+            echo -e " \033[31mFailed to install via fisher\033[0m"
         end
     else
-        echo -e "\033[90m✗\033[0m"
+        echo -e " \033[90m✘\033[0m"
     end
     
     echo -n "  omf: "
     if command -v omf >/dev/null 2>&1
-        echo -e "\033[32m✓\033[0m"
+        echo -e " \033[32m✔\033[0m"
         echo "Installing bass via Oh My Fish..."
         # Show OMF output
         omf install bass
         if test $status -eq 0
-            echo -e "\033[32mBass installed successfully via OMF\033[0m"
+            echo -e " \033[32mBass installed successfully via OMF\033[0m"
             echo "Please restart your fish shell to complete setup"
             return 0
         else
-            echo -e "\033[31mFailed to install via OMF\033[0m"
+            echo -e " \033[31mFailed to install via OMF\033[0m"
         end
     else
-        echo -e "\033[90m✗\033[0m"
+        echo -e " \033[90m✘\033[0m"
     end
     
     echo -n "  fundle: "
     if functions -q fundle >/dev/null 2>&1
-        echo -e "\033[32m✓\033[0m"
+        echo -e " \033[32m✔\033[0m"
         echo "Installing bass via fundle..."
         # Show fundle output
         fundle plugin 'edc/bass'
         fundle install
         if test $status -eq 0
-            echo -e "\033[32mBass installed successfully via fundle\033[0m"
+            echo -e " \033[32mBass installed successfully via fundle\033[0m"
             echo "Please restart your fish shell to complete setup"
             return 0
         else
-            echo -e "\033[31mFailed to install via fundle\033[0m"
+            echo -e " \033[31mFailed to install via fundle\033[0m"
         end
     else
-        echo -e "\033[90m✗\033[0m"
+        echo -e " \033[90m✘\033[0m"
     end
 
     # No plugin manager available - compile from source
@@ -70,20 +70,20 @@ function __nvm_setup_bass --description 'Setup bass environment for nvm integrat
     echo -n "Downloading bass source code... "
     # Show download with progress
     if curl -L --progress-bar --fail https://github.com/edc/bass/archive/master.tar.gz -o /tmp/bass.tar.gz
-        echo -e "\033[32m✓\033[0m"
+        echo -e " \033[32m✔\033[0m"
     else
-        echo -e "\033[31m✗\033[0m"
-        echo -e "\033[31mDownload failed\033[0m"
+        echo -e " \033[31m✘\033[0m"
+        echo -e " \033[31mDownload failed\033[0m"
         return 1
     end
     
     echo -n "Extracting source... "
     # Show extraction process
     if tar -xzf /tmp/bass.tar.gz -C /tmp 2>/dev/null
-        echo -e "\033[32m✓\033[0m"
+        echo -e " \033[32m✔\033[0m"
     else
-        echo -e "\033[31m✗\033[0m"
-        echo -e "\033[31mExtraction failed\033[0m"
+        echo -e " \033[31m✘\033[0m"
+        echo -e " \033[31mExtraction failed\033[0m"
         rm -f /tmp/bass.tar.gz
         return 1
     end
@@ -102,11 +102,11 @@ function __nvm_setup_bass --description 'Setup bass environment for nvm integrat
         echo "rm -f '$uninstall_script'" >> "$uninstall_script"
         chmod +x "$uninstall_script"
         
-        echo -e "\033[32mBass compiled and installed successfully\033[0m"
+        echo -e " \033[32mBass compiled and installed successfully\033[0m"
         echo "Installation path: $fish_functions_dir"
         echo "Uninstall script: $uninstall_script"
     else
-        echo -e "\033[31mBass source files not found\033[0m"
+        echo -e " \033[31mBass source files not found\033[0m"
         rm -rf /tmp/bass-master /tmp/bass.tar.gz
         return 1
     end
@@ -140,7 +140,7 @@ function __nvm_auto_configure_fish --description 'Configure Fish shell for nvm i
     echo "# You must call it on initialization or directory switching won't work" >> "$fish_config_file"
     echo "load_nvm > /dev/stderr" >> "$fish_config_file"
     
-    echo -e "\033[32mFish integration configured\033[0m"
+    echo -e " \033[32mFish integration configured\033[0m"
     
     # Load immediately for current session
     load_nvm > /dev/stderr
@@ -196,7 +196,7 @@ function __nvm_run_setup --description 'Run complete nvm-fish setup'
     
     # Setup bass environment
     if not __nvm_ensure_bass
-        echo -e "\033[31mSetup failed\033[0m"
+        echo -e " \033[31mSetup failed\033[0m"
         return 1
     end
     
@@ -209,7 +209,7 @@ function __nvm_run_setup --description 'Run complete nvm-fish setup'
     touch "$setup_marker_file"
     
     echo ""
-    echo -e "\033[32mSetup complete!\033[0m"
+    echo -e " \033[32mSetup complete!\033[0m"
     echo ""
     echo "Available features:"
     echo "  • All nvm commands work in Fish shell"
@@ -245,7 +245,7 @@ function __nvm_ensure_bass --description 'Ensure bass is available for nvm comma
     end
     
     # Installation failed
-    echo -e "\033[31mBass setup failed\033[0m"
+    echo -e " \033[31mBass setup failed\033[0m"
     echo ""
     echo "Possible causes:"
     echo "  • Network connection issues"

--- a/load_nvm.fish
+++ b/load_nvm.fish
@@ -32,15 +32,18 @@ function load_nvm --on-variable="PWD" --description 'Automatically switch Node.j
       # Check if we're already using this version (avoid unnecessary nvm calls)
       set -l current_version_check (node --version 2>/dev/null | string replace 'v' '')
       set -l target_version (string replace 'v' '' "$nvmrc_content")
-      
+
+      # Extract pure version number (remove npm info if present)
+      set -l pure_version (string match -rg '^([0-9]+\.[0-9]+\.[0-9]+)' "$target_version" || echo "$target_version")
+
       if test "$current_version_check" != "$target_version"
-        set -l nvmrc_node_version (nvm version "$nvmrc_content" 2>/dev/null)
+        set -l nvmrc_node_version (nvm version "$pure_version" 2>/dev/null)
         if test "$nvmrc_node_version" = "N/A"
           # Use direct bass call to avoid .nvmrc management prompts
-          bass source ~/.nvm/nvm.sh --no-use ';' nvm install "$nvmrc_content"
+          bass source ~/.nvm/nvm.sh --no-use ';' nvm install "$pure_version"
         else
           # Use direct bass call to avoid .nvmrc management prompts
-          bass source ~/.nvm/nvm.sh --no-use ';' nvm use "$nvmrc_content"
+          bass source ~/.nvm/nvm.sh --no-use ';' nvm use "$pure_version"
         end
       end
     end

--- a/load_nvm.fish
+++ b/load_nvm.fish
@@ -23,9 +23,20 @@ function load_nvm --on-variable="PWD" --description 'Automatically switch Node.j
     end
   end
   
-  # Only check for .nvmrc in current directory (fast file check)
-  set -l nvmrc_path "$PWD/.nvmrc"
-  if test -f "$nvmrc_path"
+  # Look for .nvmrc in current or parent directories
+  set -l nvmrc_path ""
+  set -l current_dir "$PWD"
+
+  # Search up the directory tree for .nvmrc
+  while test -z "$nvmrc_path" -a "$current_dir" != "/"
+    if test -f "$current_dir/.nvmrc"
+      set nvmrc_path "$current_dir/.nvmrc"
+    else
+      set current_dir (dirname "$current_dir")
+    end
+  end
+
+  if test -n "$nvmrc_path" -a -f "$nvmrc_path"
     # Only call nvm if there's actually a .nvmrc file
     set -l nvmrc_content (cat "$nvmrc_path" 2>/dev/null | string trim)
     if test -n "$nvmrc_content"

--- a/load_nvm.fish
+++ b/load_nvm.fish
@@ -45,16 +45,22 @@ function load_nvm --on-variable="PWD" --description 'Automatically switch Node.j
       set -l target_version (string replace 'v' '' "$nvmrc_content")
 
       # Extract pure version number (remove npm info if present)
-      set -l pure_version (string match -rg '^([0-9]+\.[0-9]+\.[0-9]+)' "$target_version" || echo "$target_version")
+      if string match -rq '^([0-9]+\.[0-9]+\.[0-9]+)' "$target_version"
+        set -l pure_version (string match -rg '^([0-9]+\.[0-9]+\.[0-9]+)' "$target_version")
+      else
+        set -l pure_version "$target_version"
+      end
 
       # Compare using pure version numbers
       if test "$current_version_check" != "$pure_version"
         set -l nvmrc_node_version (nvm version "$pure_version" 2>/dev/null)
         if test "$nvmrc_node_version" = "N/A"
           # Use direct bass call to avoid .nvmrc management prompts
+          set -lx NVM_AUTO 1
           bass source ~/.nvm/nvm.sh --no-use ';' nvm install "$pure_version"
         else
           # Use direct bass call to avoid .nvmrc management prompts
+          set -lx NVM_AUTO 1
           bass source ~/.nvm/nvm.sh --no-use ';' nvm use "$pure_version"
         end
       end
@@ -64,6 +70,7 @@ function load_nvm --on-variable="PWD" --description 'Automatically switch Node.j
     # This avoids calling nvm on every directory without .nvmrc
     if test -n "$NVM_BIN" -a "$NVM_BIN" != "$HOME/.nvm/versions/node/$(nvm version default 2>/dev/null)/bin"
       # Use direct bass call to avoid .nvmrc management prompts and output
+      set -lx NVM_AUTO 1
       bass source ~/.nvm/nvm.sh --no-use ';' nvm use default
     end
   end

--- a/load_nvm.fish
+++ b/load_nvm.fish
@@ -45,8 +45,9 @@ function load_nvm --on-variable="PWD" --description 'Automatically switch Node.j
       set -l target_version (string replace 'v' '' "$nvmrc_content")
 
       # Extract pure version number (remove npm info if present)
-      if string match -rq '^([0-9]+\.[0-9]+\.[0-9]+)' "$target_version"
-        set -l pure_version (string match -rg '^([0-9]+\.[0-9]+\.[0-9]+)' "$target_version")
+      set -l version_regex '^([0-9]+\.[0-9]+\.[0-9]+)'
+      if string match -rq $version_regex "$target_version"
+        set -l pure_version (string match -rg $version_regex "$target_version")
       else
         set -l pure_version "$target_version"
       end

--- a/load_nvm.fish
+++ b/load_nvm.fish
@@ -36,9 +36,11 @@ function load_nvm --on-variable="PWD" --description 'Automatically switch Node.j
       if test "$current_version_check" != "$target_version"
         set -l nvmrc_node_version (nvm version "$nvmrc_content" 2>/dev/null)
         if test "$nvmrc_node_version" = "N/A"
-          nvm install "$nvmrc_content"
+          # Use direct bass call to avoid .nvmrc management prompts
+          bass source ~/.nvm/nvm.sh --no-use ';' nvm install "$nvmrc_content"
         else
-          nvm use "$nvmrc_content"
+          # Use direct bass call to avoid .nvmrc management prompts
+          bass source ~/.nvm/nvm.sh --no-use ';' nvm use "$nvmrc_content"
         end
       end
     end
@@ -46,8 +48,8 @@ function load_nvm --on-variable="PWD" --description 'Automatically switch Node.j
     # Only revert to default if we're not already on default
     # This avoids calling nvm on every directory without .nvmrc
     if test -n "$NVM_BIN" -a "$NVM_BIN" != "$HOME/.nvm/versions/node/$(nvm version default 2>/dev/null)/bin"
-      echo "Reverting to default Node version"
-      nvm use default
+      # Use direct bass call to avoid .nvmrc management prompts and output
+      bass source ~/.nvm/nvm.sh --no-use ';' nvm use default
     end
   end
 end

--- a/load_nvm.fish
+++ b/load_nvm.fish
@@ -47,7 +47,8 @@ function load_nvm --on-variable="PWD" --description 'Automatically switch Node.j
       # Extract pure version number (remove npm info if present)
       set -l pure_version (string match -rg '^([0-9]+\.[0-9]+\.[0-9]+)' "$target_version" || echo "$target_version")
 
-      if test "$current_version_check" != "$target_version"
+      # Compare using pure version numbers
+      if test "$current_version_check" != "$pure_version"
         set -l nvmrc_node_version (nvm version "$pure_version" 2>/dev/null)
         if test "$nvmrc_node_version" = "N/A"
           # Use direct bass call to avoid .nvmrc management prompts

--- a/nvm-fish.install
+++ b/nvm-fish.install
@@ -16,8 +16,8 @@ post_install() {
     echo "    nvm --version, nvm install node, nvm use 16, etc."
     echo ""
     echo "==> Dependencies:"
-    echo "    ✓ nvm (installed as package dependency)"
-    echo "    ✓ bass (auto-installed during nvm init)"
+    echo "    ✔ nvm (installed as package dependency)"
+    echo "    ✔ bass (auto-installed during nvm init)"
     echo ""
     echo "==> Documentation: https://github.com/your-username/nvm-fish"
 }
@@ -90,9 +90,9 @@ post_remove() {
     fi
     
     echo "==> Cleanup completed. The following were preserved:"
-    echo "    ✓ Official nvm installation and configuration"  
-    echo "    ✓ All Node.js versions installed via nvm"
-    echo "    ✓ Bass (see above for removal options if needed)"
+    echo "    ✔ Official nvm installation and configuration"  
+    echo "    ✔ All Node.js versions installed via nvm"
+    echo "    ✔ Bass (see above for removal options if needed)"
     echo ""
     echo "==> IMPORTANT: Please restart your Fish shell to clear function cache:"
     echo "    - Close and reopen your terminal, OR"

--- a/nvm.fish
+++ b/nvm.fish
@@ -16,7 +16,7 @@ function nvm --description 'Node Version Manager - Fish shell integration'
   
   # Check if nvm-fish is initialized
   if not __nvm_check_setup
-    echo -e "\033[33mnvm-fish not initialized\033[0m"
+    echo -e " \033[33mnvm-fish not initialized\033[0m"
     echo ""
     echo "Run: nvm init"
     echo ""
@@ -25,7 +25,7 @@ function nvm --description 'Node Version Manager - Fish shell integration'
   
   # Ensure bass is available (quick check)
   if not __nvm_ensure_bass_quick
-    echo -e "\033[31mBass not available\033[0m"
+    echo -e " \033[31mBass not available\033[0m"
     echo "Try: nvm init"
     echo ""
     return 1
@@ -33,26 +33,39 @@ function nvm --description 'Node Version Manager - Fish shell integration'
   
   # Handle nvm use command with .nvmrc management
   if test "$argv[1]" = "use" -a (count $argv) -gt 1
-    # Execute nvm use command first
-    bass source ~/.nvm/nvm.sh --no-use ';' nvm $argv
+    # Execute nvm use command and capture output
+    set -l nvm_output (bass source ~/.nvm/nvm.sh --no-use ';' nvm $argv 2>&1)
+
+    # Display nvm output to user
+    if test -n "$nvm_output"
+      echo "$nvm_output"
+    end
 
     # Check if nvm use command succeeded
     if test $status -eq 0
-      # Get the actual Node.js version after switching
-      set -l current_version (node --version 2>/dev/null | string replace 'v' '')
+      # Extract version from nvm output (e.g., "Now using node v18.17.0 (npm v9.6.7)")
+      set -l node_current_version (string match -rg 'Now using node v([0-9]+\.[0-9]+\.[0-9]+.*)' "$nvm_output")
 
       # Handle .nvmrc file creation/management if we got a valid version
-      if test -n "$current_version"
-        # Validate that current_version matches semantic versioning (e.g., X.Y.Z)
-        if string match -rq '^[0-9]+\.[0-9]+\.[0-9]+.*$' -- "$current_version"
-          __nvm_handle_nvmrc_file "$current_version"
+      if test -n "$node_current_version"
+        # Validate that node_current_version matches semantic versioning (e.g., X.Y.Z)
+        if string match -rq '^[0-9]+\.[0-9]+\.[0-9]+.*$' -- "$node_current_version"
+          # Only prompt for .nvmrc management if this is a manual user invocation
+          # Check if we're being called from load_nvm (automatic) or directly by user
+          set -l calling_function (status current-function)
+          if test "$calling_function" != "load_nvm"
+            __nvm_handle_nvmrc_file "$node_current_version"
+          end
         else
-          echo -e "\033[31m⚠ Warning: Unexpected Node.js version format: '$current_version'\033[0m"
-          echo -e "\033[31m   Expected format: X.Y.Z (e.g., 18.17.0)\033[0m"
+          echo -e " \033[31m⚠ Warning: Unexpected Node.js version format: '$node_current_version'\033[0m"
+          echo -e " \033[31m   Expected format: X.Y.Z (e.g., 18.17.0)\033[0m"
         end
+      else
+        echo -e " \033[31m⚠ Warning: Failed to extract Node.js version from nvm output\033[0m"
+        echo -e " \033[31m   Expected output format: 'Now using node v<version>'\033[0m"
       end
     else
-      echo -e "\033[31m✗ Failed to switch Node version\033[0m"
+      echo -e " \033[31m✘ Failed to switch Node version\033[0m"
       return 1
     end
 
@@ -66,13 +79,13 @@ end
 
 # Helper function to create .nvmrc file with error handling
 function __nvm_write_nvmrc_file --description "Write version to .nvmrc file with error handling"
-  set -l version "$argv[1]"
+  set -l node_version "$argv[1]"
 
-  if echo "$version" > "$PWD/.nvmrc" 2>/dev/null
-    echo -e "\033[32m✓ Created .nvmrc with version $version\033[0m"
+  if echo "$node_version" > "$PWD/.nvmrc" 2>/dev/null
+    echo -e " \033[32m✔ Created .nvmrc with version $node_version\033[0m"
     return 0
   else
-    echo -e "\033[31m✗ Failed to create .nvmrc file\033[0m"
+    echo -e " \033[31m✘ Failed to create .nvmrc file\033[0m"
     return 1
   end
 end
@@ -85,29 +98,40 @@ function __nvm_handle_nvmrc_file --description "Handle .nvmrc file creation or o
     # No .nvmrc exists, create new one
     __nvm_create_nvmrc "$target_version"
   else
-    # .nvmrc exists, ask user what to do
+    # .nvmrc exists, check if version is different
     set -l existing_version (string trim < "$PWD/.nvmrc")
-    __nvm_prompt_override_nvmrc "$existing_version" "$target_version"
+    if test "$existing_version" != "$target_version"
+      __nvm_prompt_override_nvmrc "$existing_version" "$target_version"
+    end
   end
 end
 
 # Create new .nvmrc file
 function __nvm_create_nvmrc --description "Create new .nvmrc file"
-  set -l version "$argv[1]"
+  set -l node_version "$argv[1]"
 
-  echo -e "\033[36m📝 No .nvmrc file found in current directory.\033[0m"
-  echo -e "\033[36m   Would you like to create one with version $version for automatic switching? [Y/n]\033[0m"
-  read -l response
+  echo -e " \033[33m🔎 No .nvmrc file found in current directory.\033[0m"
+
+  # Use stty to handle input without read> prompt
+  set -l old_stty (stty -g)
+  stty -icanon -echo
+
+  echo -n -e "    Would you like to create one with \033[1;36mNode v$node_version\033[0;22m for automatic switching? [Y/n] "
+  set -l response (head -c 1)
+  echo ""
+
+  stty $old_stty
 
   switch "$response"
     case n N
+      echo -e " \033[90m• Skipped .nvmrc creation\033[0m"
       return 1
     case "" y Y
-      __nvm_write_nvmrc_file "$version"
+      __nvm_write_nvmrc_file "$node_version"
       return 0
     case '*'
-      echo -e "\033[33m⚠  Unrecognized input '$response'. Defaulting to 'Yes'.\033[0m"
-      __nvm_write_nvmrc_file "$version"
+      echo -e " \033[33m⚠  Unrecognized input '$response'. Defaulting to 'Yes'.\033[0m"
+      __nvm_write_nvmrc_file "$node_version"
       return 0
   end
 end
@@ -117,50 +141,66 @@ function __nvm_prompt_override_nvmrc --description "Prompt user to override exis
   set -l existing_version "$argv[1]"
   set -l target_version "$argv[2]"
 
-  echo -e "\033[33m📄 .nvmrc already exists in current directory.\033[0m"
-  echo -e "\033[33m   Current version: $existing_version\033[0m"
-  echo -e "\033[33m   Target version:  $target_version\033[0m"
+  echo -e " \033[33m✒  .nvmrc already exists in current directory.\033[0m"
+  echo -e " \033[33m   Current version: $existing_version\033[0m"
+  echo -e " \033[33m   Target version:  $target_version\033[0m"
   echo ""
-  echo -e "\033[36mWhat would you like to do?\033[0m"
-  echo -e "\033[36m  1) Keep existing .nvmrc\033[0m"
-  echo -e "\033[36m  2) Override with backup\033[0m"
-  echo -e "\033[36m  3) Override without backup\033[0m"
-  echo -e "\033[36m   [1/2/3] \033[0m"
+  echo -e " \033[36mWhat would you like to do?\033[0m"
+  echo -e " \033[36m  1) Keep existing .nvmrc\033[0m"
+  echo -e " \033[36m  2) Override with backup\033[0m"
+  echo -e " \033[36m  3) Override without backup\033[0m"
 
-  read -l response
+  # Use stty to handle input without read> prompt
+  set -l old_stty (stty -g)
+  stty -icanon -echo
+
+  echo -n -e " \033[36m   [1/2/3] \033[0m"
+  set -l response (head -c 1)
+  echo ""
+
+  stty $old_stty
 
   switch "$response"
     case '2'
       if __nvm_backup_nvmrc
         # Backup successful, now attempt override
         if echo "$target_version" > "$PWD/.nvmrc" 2>/dev/null
-          echo -e "\033[32m✓ Overridden .nvmrc with version $target_version (backup saved)\033[0m"
+          echo -e " \033[32m✔ Overridden .nvmrc with version $target_version (backup saved)\033[0m"
         else
-          echo -e "\033[31m✗ Backup succeeded but failed to override .nvmrc file\033[0m"
+          echo -e " \033[31m✘ Backup succeeded but failed to override .nvmrc file\033[0m"
         end
       else
         # Backup failed, ask if user wants to override without backup
-        echo -e "\033[33m⚠ Backup failed, but you can still override.\033[0m"
-        echo -e "\033[36m   Override anyway? [y/N] \033[0m"
-        read -l backup_fail_response
+        echo -e " \033[33m⚠ Backup failed, but you can still override.\033[0m"
+
+        # Use stty for second input
+        set -l old_stty2 (stty -g)
+        stty -icanon -echo
+
+        echo -n -e " \033[36m   Override anyway? [y/N] \033[0m"
+        set -l backup_fail_response (head -c 1)
+        echo ""
+
+        stty $old_stty2
+
         if test "$backup_fail_response" = "y" -or "$backup_fail_response" = "Y"
           if echo "$target_version" > "$PWD/.nvmrc" 2>/dev/null
-            echo -e "\033[32m✓ Overridden .nvmrc with version $target_version\033[0m"
+            echo -e " \033[32m✔ Overridden .nvmrc with version $target_version\033[0m"
           else
-            echo -e "\033[31m✗ Failed to override .nvmrc file\033[0m"
+            echo -e " \033[31m✘ Failed to override .nvmrc file\033[0m"
           end
         else
-          echo -e "\033[90m• Kept existing .nvmrc\033[0m"
+          echo -e " \033[90m• Kept existing .nvmrc\033[0m"
         end
       end
     case '3'
       if echo "$target_version" > "$PWD/.nvmrc" 2>/dev/null
-        echo -e "\033[32m✓ Overridden .nvmrc with version $target_version\033[0m"
+        echo -e " \033[32m✔ Overridden .nvmrc with version $target_version\033[0m"
       else
-        echo -e "\033[31m✗ Failed to override .nvmrc file\033[0m"
+        echo -e " \033[31m✘ Failed to override .nvmrc file\033[0m"
       end
     case '*'
-      echo -e "\033[90m• Kept existing .nvmrc\033[0m"
+      echo -e " \033[90m• Kept existing .nvmrc\033[0m"
   end
 end
 
@@ -169,7 +209,7 @@ function __nvm_backup_nvmrc --description "Backup existing .nvmrc file"
   # Create .nvm directory if it doesn't exist
   if not test -d "$PWD/.nvm"
     if not mkdir -p "$PWD/.nvm" 2>/dev/null
-      echo -e "\033[31m✗ Failed to create .nvm directory\033[0m"
+      echo -e " \033[31m✘ Failed to create .nvm directory\033[0m"
       return 1
     end
   end
@@ -182,9 +222,9 @@ function __nvm_backup_nvmrc --description "Backup existing .nvmrc file"
   if cp "$PWD/.nvmrc" "$backup_file" 2>/dev/null
     return 0
   else
-    echo -e "\033[31m✗ Failed to create backup\033[0m"
-    echo -e "\033[33m   Possible causes: permission denied, disk full, or file system read-only\033[0m"
-    echo -e "\033[33m   Backup path: $backup_file\033[0m"
+    echo -e " \033[31m✘ Failed to create backup\033[0m"
+    echo -e " \033[33m   Possible causes: permission denied, disk full, or file system read-only\033[0m"
+    echo -e " \033[33m   Backup path: $backup_file\033[0m"
     return 1
   end
 end

--- a/nvm.fish
+++ b/nvm.fish
@@ -44,7 +44,7 @@ function nvm --description 'Node Version Manager - Fish shell integration'
     # Check if nvm use command succeeded
     if test $status -eq 0
       # Extract version from nvm output (e.g., "Now using node v18.17.0 (npm v9.6.7)")
-      set -l node_current_version (string match -rg 'Now using node v([0-9]+\.[0-9]+\.[0-9]+.*)' "$nvm_output")
+      set -l node_current_version (string match -rg 'Now using node v([0-9]+\.[0-9]+\.[0-9]+)' "$nvm_output")
 
       # Handle .nvmrc file creation/management if we got a valid version
       if test -n "$node_current_version"
@@ -113,8 +113,11 @@ function __nvm_create_nvmrc --description "Create new .nvmrc file"
   echo -e " \033[33m🔎 No .nvmrc file found in current directory.\033[0m"
 
   # Use stty to handle input without read> prompt
-  set -l old_stty (stty -g)
-  stty -icanon -echo
+  if not set -l old_stty (stty -g 2>/dev/null)
+    echo -e " \033[31m⚠ Failed to save terminal settings\033[0m"
+    return 1
+  end
+  stty -icanon -echo 2>/dev/null
 
   echo -n -e "    Would you like to create one with \033[1;36mNode v$node_version\033[0;22m for automatic switching? [Y/n] "
   set -l response (head -c 1)
@@ -151,8 +154,11 @@ function __nvm_prompt_override_nvmrc --description "Prompt user to override exis
   echo -e " \033[36m  3) Override without backup\033[0m"
 
   # Use stty to handle input without read> prompt
-  set -l old_stty (stty -g)
-  stty -icanon -echo
+  if not set -l old_stty (stty -g 2>/dev/null)
+    echo -e " \033[31m⚠ Failed to save terminal settings\033[0m"
+    return 1
+  end
+  stty -icanon -echo 2>/dev/null
 
   echo -n -e " \033[36m   [1/2/3] \033[0m"
   set -l response (head -c 1)
@@ -174,8 +180,11 @@ function __nvm_prompt_override_nvmrc --description "Prompt user to override exis
         echo -e " \033[33m⚠ Backup failed, but you can still override.\033[0m"
 
         # Use stty for second input
-        set -l old_stty2 (stty -g)
-        stty -icanon -echo
+        if not set -l old_stty2 (stty -g 2>/dev/null)
+          echo -e " \033[31m⚠ Failed to save terminal settings\033[0m"
+          return 1
+        end
+        stty -icanon -echo 2>/dev/null
 
         echo -n -e " \033[36m   Override anyway? [y/N] \033[0m"
         set -l backup_fail_response (head -c 1)

--- a/nvm.fish
+++ b/nvm.fish
@@ -51,9 +51,9 @@ function nvm --description 'Node Version Manager - Fish shell integration'
         # Validate that node_current_version matches semantic versioning (e.g., X.Y.Z)
         if string match -rq '^[0-9]+\.[0-9]+\.[0-9]+.*$' -- "$node_current_version"
           # Only prompt for .nvmrc management if this is a manual user invocation
-          # Check if we're being called from load_nvm (automatic) or directly by user
-          set -l calling_function (status current-function)
-          if test "$calling_function" != "load_nvm"
+          # Check if we're being called automatically (from load_nvm) or directly by user
+          # Use NVM_AUTO environment variable to indicate automatic invocation
+          if not set -q NVM_AUTO
             __nvm_handle_nvmrc_file "$node_current_version"
           end
         else


### PR DESCRIPTION
## 摘要
修复了v1.1.0版本发布后发现的几个关键问题，提升.nvmrc管理功能的稳定性和用户体验。

## 修复内容

### 🔧 修复.nvmrc管理功能的关键问题
- 修复版本号总是写入4.0.8而不是实际版本号的问题
- 重命名version变量避免与Fish特殊变量冲突
- 改进版本号提取正则表达式

### 🔧 修复自动切换版本时的语法错误
- 解决load_nvm.fish中的bass命令解析问题
- 当.nvmrc文件包含npm版本信息时提取纯版本号
- 避免语法错误：`source ~/.nvm/nvm.sh --no-use ; nvm use 16.20.2 (npm v8.19.4)`

### 🔧 支持父目录.nvmrc文件查找
- 修复子目录中不遵循父目录.nvmrc的问题
- 在load_nvm.fish中实现向上查找.nvmrc文件
- 从当前目录开始，逐级向上搜索直到根目录

### 🚀 优化版本比较逻辑避免重复调用
- 修复进入子目录时重复调用nvm use的问题
- 使用纯版本号进行比较而非完整字符串
- 避免在已使用正确版本时重复切换

## 测试场景
- ✅ 版本号正确写入.nvmrc文件
- ✅ 目录切换时不会自动触发.nvmrc管理提示
- ✅ 进入有.nvmrc目录的子目录时能正确继承版本配置
- ✅ 交互式输入正常工作，用户体验良好
- ✅ 避免重复的版本切换输出

## 相关链接
- 关联版本：v1.1.0
- 原PR：#3 (智能.nvmrc管理功能)